### PR TITLE
supporting user color theme

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,6 @@
 ---
 permalink: /404.html
-layout: default
+layout: base
 ---
 
 <style type="text/css" media="screen">

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ source "https://rubygems.org"
 # Happy Jekylling!
 #gem "jekyll", "~> 4.2.2"
 
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem 'minima', '~> 2.5', '>= 2.5.1'
+# Jekyll plugin for building Jekyll sites with any public GitHub-hosted theme
+gem "jekyll-remote-theme"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,17 +6,17 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.3)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.23.8)
+    commonmarker (0.23.9)
     concurrent-ruby (1.2.2)
-    dnsruby (1.61.9)
-      simpleidn (~> 0.1)
+    dnsruby (1.70.0)
+      simpleidn (~> 0.2.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -210,7 +210,7 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.18.0)
-    nokogiri (1.14.2-aarch64-linux)
+    nokogiri (1.14.3-aarch64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -255,7 +255,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages (~> 228)
   http_parser.rb (~> 0.6.0)
-  minima (~> 2.5, >= 2.5.1)
+  jekyll-remote-theme
   tzinfo (~> 2.0)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/_config.yml
+++ b/_config.yml
@@ -19,19 +19,30 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Hwai-En's Blog
-author: Hwai-En Ho
-email: blog@hwaien.com
+author:
+  name: Hwai-En Ho
+  email: blog@hwaien.com
 description: >- # this means to ignore newlines until "baseurl:"
   A blog about software.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://hwaien.com" # the base hostname & protocol for your site, e.g. http://example.com
-#twitter_username: jekyllrb
-github_username: hwaien
 
 # Build settings
-theme: minima
+remote_theme: jekyll/minima
 plugins:
+  - jekyll-remote-theme
   - jekyll-feed
+
+minima:
+  skin: auto
+  social_links:
+    - platform: linkedin
+      title: Find me on LinkedIn
+      user_url: "https://www.linkedin.com/in/hwaien/"
+    - platform: github
+      title: Find me on GitHub
+      user_url: "https://github.com/hwaien"
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to


### PR DESCRIPTION
The blog should respect the user's system theme. If the user's system color theme is dark, the blog should render in dark theme.  If the user's system color theme is light, the blog should render in light theme.

We accomplish this by upgrading to use Jekyll [Minima](https://github.com/jekyll/minima) v3, which supports this behavior with its `auto` skin. The `auto` skin achieve the desired behavior by using the [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) CSS media feature to detect if a user has requested light or dark color themes. A user indicates their preference through an operating system setting (e.g. light or dark mode) or a user agent setting.